### PR TITLE
Add user login routes

### DIFF
--- a/src/main/java/com/example/escola/controller/UserController.java
+++ b/src/main/java/com/example/escola/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.example.escola.controller;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.escola.model.UserModel;
+import com.example.escola.service.UserService;
+
+@CrossOrigin(origins = "*")
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    @Autowired
+    private UserService service;
+
+    @PostMapping("/register")
+    public UserModel register(@RequestBody UserModel user) {
+        return service.salvar(user);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody Map<String, String> credentials) {
+        String username = credentials.get("username");
+        String password = credentials.get("password");
+        Optional<UserModel> user = service.login(username, password);
+        if (user.isPresent()) {
+            return ResponseEntity.ok("Login successful");
+        }
+        return ResponseEntity.status(401).body("Invalid credentials");
+    }
+}

--- a/src/main/java/com/example/escola/model/UserModel.java
+++ b/src/main/java/com/example/escola/model/UserModel.java
@@ -1,0 +1,28 @@
+package com.example.escola.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserModel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+}

--- a/src/main/java/com/example/escola/repository/UserRepository.java
+++ b/src/main/java/com/example/escola/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.example.escola.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.escola.model.UserModel;
+
+@Repository
+public interface UserRepository extends JpaRepository<UserModel, Long> {
+    Optional<UserModel> findByUsernameAndPassword(String username, String password);
+    Optional<UserModel> findByUsername(String username);
+}

--- a/src/main/java/com/example/escola/service/UserService.java
+++ b/src/main/java/com/example/escola/service/UserService.java
@@ -1,0 +1,28 @@
+package com.example.escola.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.escola.model.UserModel;
+import com.example.escola.repository.UserRepository;
+
+@Service
+public class UserService {
+
+    @Autowired
+    private UserRepository repository;
+
+    public UserModel salvar(UserModel user) {
+        return repository.save(user);
+    }
+
+    public Optional<UserModel> buscarPorUsername(String username) {
+        return repository.findByUsername(username);
+    }
+
+    public Optional<UserModel> login(String username, String password) {
+        return repository.findByUsernameAndPassword(username, password);
+    }
+}

--- a/src/test/java/com/example/apialunos/ApialunosApplicationTests.java
+++ b/src/test/java/com/example/apialunos/ApialunosApplicationTests.java
@@ -1,13 +1,27 @@
 package com.example.apialunos;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import com.example.escola.service.UserService;
+import com.example.escola.model.UserModel;
 
 @SpringBootTest
 class ApialunosApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Autowired
+    private UserService userService;
 
+    @Test
+    void contextLoads() {
+        assertThat(userService).isNotNull();
+    }
+
+    @Test
+    void loginFailsWithInvalidCredentials() {
+        assertThat(userService.login("invalid", "invalid").isPresent()).isFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- add `UserModel` entity
- add `UserRepository`
- add `UserService`
- create `UserController` with register and login routes
- expand application tests to check login service

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68447413c7808331a2717064c1439cda